### PR TITLE
drivers: mtd: spi-nor: Add ISSI's is25lp016d

### DIFF
--- a/drivers/mtd/spi-nor/spi-nor.c
+++ b/drivers/mtd/spi-nor/spi-nor.c
@@ -866,7 +866,8 @@ static const struct flash_info spi_nor_ids[] = {
 			SECT_4K | SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ) },
 	{ "is25lq016b", INFO(0x9d4015, 0, 64 * 1024, 32,
 			SECT_4K | SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ) },
-
+	{ "is25lp016d", INFO(0x9d6015, 0, 64 * 1024, 32,
+			SECT_4K | SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ) },
 
 	/* Macronix */
 	{ "mx25l512e",   INFO(0xc22010, 0, 64 * 1024,   1, SECT_4K) },


### PR DESCRIPTION
Added the is25lp016d to sip_nor_ids so that its JEDEC ID (0x9d6015) is recognized.

Done in a manner like this 2018 patch: https://patchwork.kernel.org/patch/10663927/

Upstream linux already has support for this part, but the spi-nor directory was reorganized in the past year, so it isn't practical to bring that commit into this 4.9 tree.