### PR TITLE
Disable DMA on RS-485 ports

### DIFF
--- a/arch/arm/boot/dts/imx6ul-ts4100-ts8100.dtsi
+++ b/arch/arm/boot/dts/imx6ul-ts4100-ts8100.dtsi
@@ -37,6 +37,7 @@
 	 * with the command 'tshwctl --out 0x33 --in 0x1'
 	 */
 	rts-gpios = <&gpio1 18 GPIO_ACTIVE_HIGH>;
+	dma-names = "", "";
 	linux,rs485-enabled-at-boot-time;
 };
 

--- a/arch/arm/boot/dts/imx6ul-ts4100-ts8551.dtsi
+++ b/arch/arm/boot/dts/imx6ul-ts4100-ts8551.dtsi
@@ -50,9 +50,10 @@
 	uart-has-rtscts;
 	/* gpio 1_18 is initialized by the hog group in 4100.dtsi
 	 * It is the SPARE_1 pin, needs to be set up in FPGA to pass to TXEN
-	 * with the command 'tshwctl --out 0x31 --in 0x2'
+	 * with the command 'tshwctl --out 0x31 --in 0x1'
 	 */
 	rts-gpios = <&gpio1 18 GPIO_ACTIVE_HIGH>;
+	dma-names = "", "";
 	linux,rs485-enabled-at-boot-time;
 };
 

--- a/arch/arm/boot/dts/imx6ul-ts4100-ts8820.dtsi
+++ b/arch/arm/boot/dts/imx6ul-ts4100-ts8820.dtsi
@@ -30,6 +30,7 @@
 	 * with the command 'tshwctl --out 0x31 --in 0x1'
 	 */
 	rts-gpios = <&gpio1 18 GPIO_ACTIVE_HIGH>;
+	dma-names = "", "";
 	linux,rs485-enabled-at-boot-time;
 };
 

--- a/arch/arm/boot/dts/imx6ul-ts7553v2.dts
+++ b/arch/arm/boot/dts/imx6ul-ts7553v2.dts
@@ -327,6 +327,7 @@
 
 	uart-has-rtscts;
 	rts-gpios = <&gpio1 22 GPIO_ACTIVE_LOW>;
+	dma-names = "", "";
 	linux,rs485-enabled-at-boot-time;
 };
 

--- a/arch/arm/boot/dts/imx6ul-tsmflow.dts
+++ b/arch/arm/boot/dts/imx6ul-tsmflow.dts
@@ -328,6 +328,7 @@
 
 	uart-has-rtscts;
 	rts-gpios = <&gpio1 30 GPIO_ACTIVE_HIGH>;
+	dma-names = "", "";
 	linux,rs485-enabled-at-boot-time;
 };
 


### PR DESCRIPTION
Since previously enabling DMA on UARTs, TXEN on RS-485 ports has an issue.

The workaround for now is to just disable DMA on these ports.

This fix was tested on a TS-8551-4100 board, testing both UART3 and UART4. UART3 RS-485 functionality was verified via logic analyzer. The usual data patterns that would trigger TXEN remaining asserted for long periods of time was not observed.

Higher baud rate operation was also confirmed on UART4 via linux-serial-test connected to a host PC with the TS-8551-4100 receiving test data. This was run at 921600 baud for several minutes to confirm no buffer overruns.